### PR TITLE
fix: use semver-compatible version names

### DIFF
--- a/.changeset/curvy-kangaroos-agree.md
+++ b/.changeset/curvy-kangaroos-agree.md
@@ -1,0 +1,5 @@
+---
+'changesets-snapshot': patch
+---
+
+Fix publish to use semver-compatible version names

--- a/src/__snapshots__/publish.test.ts.snap
+++ b/src/__snapshots__/publish.test.ts.snap
@@ -10,13 +10,13 @@ exports[`command output for npm: logger.log 1`] = `
 
 exports[`command output for npm: run 1`] = `
 [
-  "node /__mocked_node_modules__/@changesets/cli/bin.js version --snapshot feature_123-branch",
+  "node /__mocked_node_modules__/@changesets/cli/bin.js version --snapshot feature-123-branch",
 ]
 `;
 
 exports[`command output for npm: runPublish 1`] = `
 [
-  "node /__mocked_node_modules__/@changesets/cli/bin.js publish --tag feature_123-branch",
+  "node /__mocked_node_modules__/@changesets/cli/bin.js publish --tag feature-123-branch",
 ]
 `;
 
@@ -49,10 +49,10 @@ exports[`command output for npm: summary 2`] = `
 exports[`command output for npm: summary 3`] = `
 [
   [
-    "npm i @multiple/package1@feature_123-branch",
+    "npm i @multiple/package1@feature-123-branch",
   ],
   [
-    "npm i @multiple/package-two@feature_123-branch",
+    "npm i @multiple/package-two@feature-123-branch",
   ],
 ]
 `;
@@ -67,13 +67,13 @@ exports[`command output for pnpm: logger.log 1`] = `
 
 exports[`command output for pnpm: run 1`] = `
 [
-  "node /__mocked_node_modules__/@changesets/cli/bin.js version --snapshot feature_123-branch",
+  "node /__mocked_node_modules__/@changesets/cli/bin.js version --snapshot feature-123-branch",
 ]
 `;
 
 exports[`command output for pnpm: runPublish 1`] = `
 [
-  "node /__mocked_node_modules__/@changesets/cli/bin.js publish --tag feature_123-branch",
+  "node /__mocked_node_modules__/@changesets/cli/bin.js publish --tag feature-123-branch",
 ]
 `;
 
@@ -106,10 +106,10 @@ exports[`command output for pnpm: summary 2`] = `
 exports[`command output for pnpm: summary 3`] = `
 [
   [
-    "pnpm add @multiple/package1@feature_123-branch",
+    "pnpm add @multiple/package1@feature-123-branch",
   ],
   [
-    "pnpm add @multiple/package-two@feature_123-branch",
+    "pnpm add @multiple/package-two@feature-123-branch",
   ],
 ]
 `;
@@ -124,13 +124,13 @@ exports[`command output for yarn: logger.log 1`] = `
 
 exports[`command output for yarn: run 1`] = `
 [
-  "node /__mocked_node_modules__/@changesets/cli/bin.js version --snapshot feature_123-branch",
+  "node /__mocked_node_modules__/@changesets/cli/bin.js version --snapshot feature-123-branch",
 ]
 `;
 
 exports[`command output for yarn: runPublish 1`] = `
 [
-  "node /__mocked_node_modules__/@changesets/cli/bin.js publish --tag feature_123-branch",
+  "node /__mocked_node_modules__/@changesets/cli/bin.js publish --tag feature-123-branch",
 ]
 `;
 
@@ -163,10 +163,10 @@ exports[`command output for yarn: summary 2`] = `
 exports[`command output for yarn: summary 3`] = `
 [
   [
-    "yarn add @multiple/package1@feature_123-branch",
+    "yarn add @multiple/package1@feature-123-branch",
   ],
   [
-    "yarn add @multiple/package-two@feature_123-branch",
+    "yarn add @multiple/package-two@feature-123-branch",
   ],
 ]
 `;

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -58,7 +58,7 @@ export const publishSnapshot = async () => {
   ensureNpmrc(npmToken);
 
   const branch = github.context.ref.replace('refs/heads/', '');
-  const cleansedBranchName = branch.replace(/\//g, '_');
+  const cleansedBranchName = branch.replace(/\//g, '-');
   const changesetsCli = resolveFrom(cwd, '@changesets/cli/bin.js');
 
   // Run the snapshot version


### PR DESCRIPTION
Changes publish to replace slashes (`/`) with hyphens (`-`) rather than underscores (`_`), as per #9 .