### PR TITLE
Add a github token to the checkout action in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Once again, version packages' CI is not running. Referring to [prior art](https://github.com/seek-oss/vocab/blob/d62bf3316c638fdd2ff3a9598ad5c1bb91909e61/.github/workflows/release.yml), I think adding a github token to the checkout action in the release workflow should fix this.