### PR TITLE
Support Trusted Publishing

### DIFF
--- a/src/publish.test.ts
+++ b/src/publish.test.ts
@@ -76,20 +76,6 @@ test.each(testCases)('command output for %s', async (packageManager) => {
 });
 
 describe('error handling', () => {
-  test('missing NPM token', async () => {
-    process.env.GITHUB_TOKEN = '@github-token';
-
-    await expect(() => publishSnapshot()).rejects.toMatchInlineSnapshot(
-      `[Error: Unable to retrieve NPM publish token]`,
-    );
-
-    expect(coreMock.setFailed.mock.calls[0]).toMatchInlineSnapshot(`
-      [
-        "Unable to retrieve NPM publish token",
-      ]
-    `);
-  });
-
   test('missing GitHub token', async () => {
     process.env.NPM_TOKEN = '@npm-token';
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -41,11 +41,6 @@ export const publishSnapshot = async () => {
     throw failure('Unable to retrieve GitHub token');
   }
 
-  const npmToken = process.env.NPM_TOKEN;
-  if (!npmToken) {
-    throw failure('Unable to retrieve NPM publish token');
-  }
-
   const detectResult = await detect({ cwd });
   if (!detectResult) {
     throw failure('Unable to detect package manager');
@@ -58,7 +53,10 @@ export const publishSnapshot = async () => {
     await run({ script: preVersionScript, cwd });
   }
 
-  ensureNpmrc(npmToken);
+  const npmToken = process.env.NPM_TOKEN;
+  if (npmToken) {
+    ensureNpmrc(npmToken);
+  }
 
   const branch = github.context.ref.replace('refs/heads/', '');
   const cleansedBranchName = branch.replace(/\//g, '-');


### PR DESCRIPTION
NPM supports token-less publishing via Trusted publishing: https://docs.npmjs.com/trusted-publishers#supported-cicd-providers

I've been testing this via my personal repo and it seems that Changesets supports this but not our action: https://github.com/samchungy/test-trusted-publishing/actions/runs/17389886766/job/49361972195