### PR TITLE
Fix caret or tilda snapshots

### DIFF
--- a/.changeset/full-hoops-pay.md
+++ b/.changeset/full-hoops-pay.md
@@ -1,0 +1,7 @@
+---
+'changesets-snapshot': minor
+---
+
+Rewrite `workspace:^` and `workspace:~` to `workspace:*` after snapshot versioning when the referenced package was bumped.
+
+`pnpm pack` otherwise publishes a caret/tilde range on the snapshot prerelease, which can resolve to a stable release or a different snapshot instead of the version just published.

--- a/src/publish.test.ts
+++ b/src/publish.test.ts
@@ -15,6 +15,10 @@ import {
 import { logger } from './logger.js';
 import { publishSnapshot } from './publish.js';
 import { run, runPublish } from './run.js';
+import {
+  pinChangedWorkspaceRanges,
+  readWorkspacePackageVersions,
+} from './workspace-protocol.js';
 
 vi.mock('@actions/github');
 vi.mock('@actions/core');
@@ -23,11 +27,16 @@ vi.mock('resolve-from');
 vi.mock('./npm-utils.js');
 vi.mock('./run.js');
 vi.mock('./logger.js');
+vi.mock('./workspace-protocol.js');
 
 const runMock = vi.mocked(run);
 const runPublishMock = vi.mocked(runPublish);
 const coreMock = vi.mocked(core);
 const detectMock = vi.mocked(detect);
+const readWorkspacePackageVersionsMock = vi.mocked(
+  readWorkspacePackageVersions,
+);
+const pinChangedWorkspaceRangesMock = vi.mocked(pinChangedWorkspaceRanges);
 
 type MockableFunction = (...args: any[]) => any;
 
@@ -50,6 +59,8 @@ const expectSummary = () => {
 beforeEach(() => {
   process.env.GITHUB_TOKEN = '';
   process.env.NPM_TOKEN = '';
+  readWorkspacePackageVersionsMock.mockResolvedValue(new Map());
+  pinChangedWorkspaceRangesMock.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -84,6 +95,10 @@ test.each(testCases)('command output for %s', async (packageManager) => {
 
   await publishSnapshot();
 
+  expect(pinChangedWorkspaceRangesMock).toHaveBeenCalledWith(
+    process.cwd(),
+    new Map(),
+  );
   expect(getScriptCalls(runMock)).toMatchSnapshot('run');
   expect(getScriptCalls(runPublishMock)).toMatchSnapshot('runPublish');
   expect(vi.mocked(logger).log.mock.calls[0]).toMatchSnapshot('logger.log');
@@ -117,6 +132,7 @@ describe('error handling', () => {
 
     await publishSnapshot();
 
+    expect(pinChangedWorkspaceRangesMock).not.toHaveBeenCalled();
     expectSummary();
   });
 });

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -7,6 +7,10 @@ import resolveFrom from 'resolve-from';
 import { logger } from './logger.js';
 import { ensureNpmrc, removeNpmrc } from './npm-utils.js';
 import { run, runPublish } from './run.js';
+import {
+  pinChangedWorkspaceRanges,
+  readWorkspacePackageVersions,
+} from './workspace-protocol.js';
 
 const writeSummary = async ({
   title,
@@ -61,6 +65,7 @@ export const publishSnapshot = async () => {
   const branch = github.context.ref.replace('refs/heads/', '');
   const cleansedBranchName = branch.replace(/\//g, '-');
   const changesetsCli = resolveFrom(cwd, '@changesets/cli/bin.js');
+  const versionsBeforeSnapshot = await readWorkspacePackageVersions(cwd);
 
   // Run the snapshot version
   const versionResult = await run({
@@ -81,6 +86,8 @@ export const publishSnapshot = async () => {
 
     return;
   }
+
+  await pinChangedWorkspaceRanges(cwd, versionsBeforeSnapshot);
 
   const result = await runPublish({
     script: `node ${changesetsCli} publish --tag ${cleansedBranchName}`,

--- a/src/workspace-protocol.test.ts
+++ b/src/workspace-protocol.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  findChangedPackageNames,
+  rewriteWorkspaceRanges,
+} from './workspace-protocol.js';
+
+describe('findChangedPackageNames', () => {
+  test('returns packages whose version changed', () => {
+    const changed = findChangedPackageNames(
+      new Map([
+        ['@scope/changed', '1.0.0'],
+        ['@scope/unchanged', '2.0.0'],
+      ]),
+      new Map([
+        ['@scope/changed', '1.0.1-branch-20240101'],
+        ['@scope/unchanged', '2.0.0'],
+      ]),
+    );
+
+    expect([...changed]).toEqual(['@scope/changed']);
+  });
+
+  test('treats packages that appear after versioning as changed', () => {
+    const changed = findChangedPackageNames(
+      new Map([['@scope/existing', '1.0.0']]),
+      new Map([
+        ['@scope/existing', '1.0.0'],
+        ['@scope/new', '0.0.0-branch-20240101'],
+      ]),
+    );
+
+    expect([...changed]).toEqual(['@scope/new']);
+  });
+});
+
+describe('rewriteWorkspaceRanges', () => {
+  test('rewrites rolling workspace ranges only for changed packages', () => {
+    const packageJson = {
+      dependencies: {
+        '@scope/changed': 'workspace:^',
+        '@scope/changed-tilde': 'workspace:~',
+        '@scope/unchanged': 'workspace:^',
+        '@scope/unchanged-tilde': 'workspace:~',
+        external: '^1.0.0',
+      },
+      devDependencies: {
+        '@scope/changed': 'workspace:~',
+      },
+      peerDependencies: {
+        '@scope/unchanged': 'workspace:~',
+      },
+    };
+
+    const changed = rewriteWorkspaceRanges(
+      packageJson,
+      new Set(['@scope/changed', '@scope/changed-tilde']),
+    );
+
+    expect(changed).toBe(true);
+    expect(packageJson).toEqual({
+      dependencies: {
+        '@scope/changed': 'workspace:*',
+        '@scope/changed-tilde': 'workspace:*',
+        '@scope/unchanged': 'workspace:^',
+        '@scope/unchanged-tilde': 'workspace:~',
+        external: '^1.0.0',
+      },
+      devDependencies: {
+        '@scope/changed': 'workspace:*',
+      },
+      peerDependencies: {
+        '@scope/unchanged': 'workspace:~',
+      },
+    });
+  });
+
+  test('leaves workspace:* and versioned workspace specs alone', () => {
+    const packageJson = {
+      dependencies: {
+        '@scope/changed': 'workspace:*',
+        '@scope/caret-range': 'workspace:^1.2.3',
+        '@scope/tilde-range': 'workspace:~1.2.3',
+      },
+    };
+
+    const changed = rewriteWorkspaceRanges(
+      packageJson,
+      new Set(['@scope/changed', '@scope/caret-range', '@scope/tilde-range']),
+    );
+
+    expect(changed).toBe(false);
+    expect(packageJson.dependencies).toEqual({
+      '@scope/changed': 'workspace:*',
+      '@scope/caret-range': 'workspace:^1.2.3',
+      '@scope/tilde-range': 'workspace:~1.2.3',
+    });
+  });
+
+  test('returns false when nothing matches', () => {
+    const packageJson = {
+      dependencies: {
+        '@scope/unchanged': 'workspace:~',
+      },
+    };
+
+    expect(
+      rewriteWorkspaceRanges(packageJson, new Set(['@scope/changed'])),
+    ).toBe(false);
+    expect(packageJson.dependencies?.['@scope/unchanged']).toBe('workspace:~');
+  });
+});

--- a/src/workspace-protocol.ts
+++ b/src/workspace-protocol.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { type Package, getPackages } from '@manypkg/get-packages';
+
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+
+const WORKSPACE_STAR = 'workspace:*';
+const ROLLING_WORKSPACE_SPECIFIER = /^workspace:[~^]$/;
+
+type DependencyMap = Record<string, string>;
+
+type PackageJson = {
+  name?: string;
+  version?: string;
+} & Partial<Record<(typeof DEPENDENCY_FIELDS)[number], DependencyMap>>;
+
+const versionsFromPackages = (packages: Package[]): Map<string, string> =>
+  new Map(
+    packages.flatMap((pkg) => {
+      const { name, version } = pkg.packageJson;
+
+      return name && version ? [[name, version] as const] : [];
+    }),
+  );
+
+export const readWorkspacePackageVersions = async (
+  cwd: string,
+): Promise<Map<string, string>> => {
+  const { packages } = await getPackages(cwd);
+
+  return versionsFromPackages(packages);
+};
+
+export const findChangedPackageNames = (
+  versionsBeforeSnapshot: ReadonlyMap<string, string>,
+  versionsAfterSnapshot: ReadonlyMap<string, string>,
+): Set<string> => {
+  const changedPackageNames = new Set<string>();
+
+  for (const [name, version] of versionsAfterSnapshot) {
+    if (versionsBeforeSnapshot.get(name) !== version) {
+      changedPackageNames.add(name);
+    }
+  }
+
+  return changedPackageNames;
+};
+
+export const rewriteWorkspaceRanges = (
+  packageJson: PackageJson,
+  changedPackageNames: ReadonlySet<string>,
+): boolean => {
+  let changed = false;
+
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = packageJson[field];
+
+    if (!deps) {
+      continue;
+    }
+
+    for (const [name, specifier] of Object.entries(deps)) {
+      if (
+        ROLLING_WORKSPACE_SPECIFIER.test(specifier) &&
+        changedPackageNames.has(name)
+      ) {
+        deps[name] = WORKSPACE_STAR;
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+};
+
+export const pinChangedWorkspaceRanges = async (
+  cwd: string,
+  versionsBeforeSnapshot: ReadonlyMap<string, string>,
+): Promise<void> => {
+  const { packages } = await getPackages(cwd);
+  const changedPackageNames = findChangedPackageNames(
+    versionsBeforeSnapshot,
+    versionsFromPackages(packages),
+  );
+
+  if (changedPackageNames.size === 0) {
+    return;
+  }
+
+  await Promise.all(
+    packages.map(async (pkg) => {
+      const packageJsonPath = path.join(pkg.dir, 'package.json');
+      const raw = await fs.readFile(packageJsonPath, 'utf8');
+      const packageJson = JSON.parse(raw) as PackageJson;
+
+      if (!rewriteWorkspaceRanges(packageJson, changedPackageNames)) {
+        return;
+      }
+
+      await fs.writeFile(
+        packageJsonPath,
+        `${JSON.stringify(packageJson, null, 2)}`,
+      );
+    }),
+  );
+};


### PR DESCRIPTION
**Currently**

Snapshot publishes work with workspace:*. After Changesets versions the snapshot, pnpm pack rewrites that specifier to the exact version, e.g. "MY_PACKAGE": "1.0.0-my-snap".

workspace:^ and workspace:~ do not. pnpm pack rewrites them to a range on the snapshot: "MY_PACKAGE": "^1.0.0-my-snap" (or ~). A caret/tilde range means “this version or anything compatible above it”, and a prerelease sorts below the matching stable release. So ^1.0.0-my-snap can resolve to 1.0.0 / later 1.x, or to a different snapshot of the same 1.0.0, instead of the snapshot that was just published.

**After**
This action now rewrites workspace:^ and workspace:~ to workspace:* when the referenced package was bumped, so pack emits a pinned snapshot version.

Tested here on `skuba`:

<img width="1200" height="603" alt="image" src="https://github.com/user-attachments/assets/c9cadea1-0d43-490a-a5e2-b3c320c48e31" />


https://github.com/seek-oss/skuba/actions/runs/32095149458

Which emits a combination of various versions based on which packages were being changed:

<img width="594" height="139" alt="image" src="https://github.com/user-attachments/assets/f556d368-0a42-417b-b503-7658030f5f05" />
